### PR TITLE
Make nixos/modules into plain module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 ## Getting Started
 
+### Installing the NixOS module
+
+<details>
+  <summary>Flakes (recommended)</summary>
+
 First you have to add this flake as a flake input:
 
 ```nix
@@ -46,6 +51,30 @@ Next you need to add the `diskoZfs` module to your NixOS configuration. How spef
   };
 }
 ```
+
+</details>
+
+<details>
+  <summary>nix-channel</summary>
+
+First you have to add disko-zfs source as a new channel. To do that, run as root:
+
+```console
+nix-channel --add https://github.com/numtide/disko-zfs/archive/main.tar.gz disko-zfs
+nix-channel --update disko-zfs
+```
+
+Next you need to add the `diskoZfs` module to your NixOS configuration. How spefically you need to do that is highly dependant, but in the most basic case you need to add the following import to your `configuration.nix`:
+
+```nix
+{
+  imports = [ <disko-zfs/module.nix> ];
+}
+```
+
+</details>
+
+### Using the NixOS module
 
 With the module in-place, you can use `disko-zfs` like so:
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
+    inputs@{ self, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } (
       { lib, ... }:
       {
@@ -32,12 +32,10 @@
             packages.default = config.packages.disko-zfs;
           };
 
-        flake.nixosModules.default = lib.modules.importApply ./nixos/modules/default.nix {
-          inherit inputs;
+        flake.nixosModules.default = lib.modules.importApply ./nixos/modules {
+          overlay = self.overlays.default;
         };
-        flake.overlays.default = final: _: {
-          disko-zfs = final.callPackage ./package.nix { };
-        };
+        flake.overlays.default = import ./overlay.nix;
 
         systems = [
           "x86_64-linux"

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+lib.modules.importApply ./nixos/modules {
+  overlay = import ./overlay.nix;
+}

--- a/nixos/modules/default.nix
+++ b/nixos/modules/default.nix
@@ -1,4 +1,4 @@
-{ inputs }:
+{ overlay }:
 {
   pkgs,
   lib,
@@ -91,9 +91,7 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        nixpkgs.overlays = [
-          inputs.self.overlays.default
-        ];
+        nixpkgs.overlays = [ overlay ];
 
         systemd.services."disko-zfs" = {
           unitConfig.DefaultDependencies = false;

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,3 @@
+final: _: {
+  disko-zfs = final.callPackage ./package.nix { };
+}


### PR DESCRIPTION
This allows adding disko-zfs to channels, npins, etc.

E.g. with channels:
```nix
{
  imports = [ <disko-zfs/module.nix> ];
}
```

I've tried running `nix flake check`, but it seems that `vm-test-run-disko-basic.nix` just gets stuck.