### PR TITLE
property: treat none as numeric zero

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -12,6 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     root = ./.;
     fileset = lib.fileset.unions [
       ./src
+      ./tests
       ./Cargo.toml
       ./Cargo.lock
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,10 @@ where
                 continue;
             }
 
-            if actual_property.value == desired_property.value {
+            if actual_property
+                .value
+                .equivalent_for_property(&desired_property.value, desired_property_name)
+            {
                 log::trace!(
                     "dataset {} property {} already set to {}, skip",
                     dataset_name,

--- a/src/property.rs
+++ b/src/property.rs
@@ -52,6 +52,55 @@ impl PropertyValue {
             PropertyValue::String(string) => string.clone(),
         }
     }
+
+    pub fn equivalent_for_property(&self, other: &Self, property_name: &str) -> bool {
+        let none_is_sentinel = numeric_none_sentinel(property_name).is_some_and(|sentinel| {
+            matches!(
+                (self, other),
+                (Self::Number(number), Self::String(value))
+                    | (Self::String(value), Self::Number(number))
+                    if *number == sentinel && value == "none"
+            )
+        });
+
+        none_is_sentinel || self == other
+    }
+}
+
+fn numeric_none_sentinel(property_name: &str) -> Option<u64> {
+    const ZERO_SENTINEL_PROPERTIES: [&str; 11] = [
+        "quota",
+        "refquota",
+        "reservation",
+        "refreservation",
+        "defaultuserquota",
+        "defaultgroupquota",
+        "defaultprojectquota",
+        "defaultuserobjquota",
+        "defaultgroupobjquota",
+        "defaultprojectobjquota",
+        "zoned_uid",
+    ];
+    const ZERO_SENTINEL_PREFIXES: [&str; 6] = [
+        "userquota@",
+        "groupquota@",
+        "projectquota@",
+        "userobjquota@",
+        "groupobjquota@",
+        "projectobjquota@",
+    ];
+
+    if ZERO_SENTINEL_PROPERTIES.contains(&property_name)
+        || ZERO_SENTINEL_PREFIXES
+            .iter()
+            .any(|prefix| property_name.starts_with(prefix))
+    {
+        Some(0)
+    } else if matches!(property_name, "filesystem_limit" | "snapshot_limit") {
+        Some(u64::MAX)
+    } else {
+        None
+    }
 }
 
 // According to zfs_nicestrtonum in zfs/lib/libzfs/libzfs_util.c
@@ -163,6 +212,50 @@ impl Serialize for PropertyValue {
             PropertyValue::Number(num) => num.serialize(serializer),
             PropertyValue::String(str) => str.serialize(serializer),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PropertyValue;
+
+    #[test]
+    fn none_uses_each_property_numeric_sentinel() {
+        let none = PropertyValue::String("none".to_owned());
+        let zero = PropertyValue::Number(0);
+
+        for property_name in [
+            "quota",
+            "refquota",
+            "reservation",
+            "refreservation",
+            "defaultuserquota",
+            "defaultgroupquota",
+            "defaultprojectquota",
+            "defaultuserobjquota",
+            "defaultgroupobjquota",
+            "defaultprojectobjquota",
+            "zoned_uid",
+            "userquota@1000",
+            "groupquota@1000",
+            "projectquota@1000",
+            "userobjquota@1000",
+            "groupobjquota@1000",
+            "projectobjquota@1000",
+        ] {
+            assert!(none.equivalent_for_property(&zero, property_name));
+            assert!(zero.equivalent_for_property(&none, property_name));
+        }
+
+        let maximum = PropertyValue::Number(u64::MAX);
+        for property_name in ["filesystem_limit", "snapshot_limit"] {
+            assert!(none.equivalent_for_property(&maximum, property_name));
+            assert!(maximum.equivalent_for_property(&none, property_name));
+            assert!(!none.equivalent_for_property(&zero, property_name));
+        }
+
+        assert!(!none.equivalent_for_property(&zero, "special_small_blocks"));
+        assert!(!none.equivalent_for_property(&zero, "example:custom"));
     }
 }
 

--- a/tests/fixtures/none-properties-spec.json
+++ b/tests/fixtures/none-properties-spec.json
@@ -1,0 +1,24 @@
+{
+  "datasets": {
+    "zroot/dataset": {
+      "properties": {
+        "quota": "none",
+        "refquota": "none",
+        "reservation": "none",
+        "refreservation": "none",
+        "defaultuserquota": "none",
+        "defaultgroupquota": "none",
+        "defaultprojectquota": "none",
+        "defaultuserobjquota": "none",
+        "defaultgroupobjquota": "none",
+        "defaultprojectobjquota": "none",
+        "zoned_uid": "none",
+        "filesystem_limit": "none",
+        "snapshot_limit": "none",
+        "special_small_blocks": 0
+      }
+    }
+  },
+  "ignoredDatasets": [],
+  "ignoredProperties": []
+}

--- a/tests/fixtures/none-properties-zfs-list.json
+++ b/tests/fixtures/none-properties-zfs-list.json
@@ -1,0 +1,122 @@
+{
+  "output_version": {
+    "command": "zfs get",
+    "vers_major": 2,
+    "vers_minor": 3
+  },
+  "datasets": {
+    "zroot": {
+      "name": "zroot",
+      "type": "FILESYSTEM",
+      "pool": "zroot",
+      "createtxg": 1,
+      "properties": {}
+    },
+    "zroot/dataset": {
+      "name": "zroot/dataset",
+      "type": "FILESYSTEM",
+      "pool": "zroot",
+      "createtxg": 2,
+      "properties": {
+        "quota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "refquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "reservation": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "refreservation": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultuserquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultgroupquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultprojectquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultuserobjquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultgroupobjquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "defaultprojectobjquota": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "zoned_uid": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "filesystem_limit": {
+          "value": 18446744073709551615,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "snapshot_limit": {
+          "value": 18446744073709551615,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        },
+        "special_small_blocks": {
+          "value": 0,
+          "source": {
+            "type": "LOCAL",
+            "data": "none"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -1,0 +1,34 @@
+use std::{path::Path, process::Command};
+
+fn fixture(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[test]
+fn none_properties_equal_zero_in_zfs_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_disko-zfs"))
+        .args([
+            "--file",
+            &fixture("none-properties-zfs-list.json"),
+            "plan",
+            "--spec",
+            &fixture("none-properties-spec.json"),
+        ])
+        .output()
+        .expect("disko-zfs plan should run");
+
+    assert!(
+        output.status.success(),
+        "plan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "# Additive Commands\n# !! Destructive Commands !!\n"
+    );
+}


### PR DESCRIPTION
## Summary

- compare the ZFS `none` sentinel with its property-specific numeric representation only for native numeric properties that accept `none`
- cover zero-sentinel quota/reservation/default-quota/userspace-quota and `zoned_uid` properties
- cover the `UINT64_MAX` sentinel used by `filesystem_limit` and `snapshot_limit`
- keep global numeric parsing strict so user-defined/string properties containing `none` are not confused with a number
- use numeric `0` for `special_small_blocks`, whose ZFS interface does not accept `none`
- add fixture and unit coverage for the dry-activation behavior and property-specific boundaries
- include integration tests in the Nix package source fileset

## Why

`zfs get ... --json --json-int` reports disabled numeric properties as their internal sentinel, while the generated Nix specification keeps the user-facing value `"none"`. Comparing those representations directly emits false `zfs set ...=none` commands during dry activation. The equivalence must remain property-aware because `none` is also a valid literal value for custom string properties and different native properties use different numeric sentinels.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `cargo clippy --locked --all-targets` (passes with existing repository warnings)

Nix is not installed on the development host, so `nix flake check` was not run locally.

Fixes #22